### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/better-faraday.rb
+++ b/lib/better-faraday.rb
@@ -104,7 +104,7 @@ module Faraday
           ::JSON.generate(request_json)
         else
           body = env.request_body.to_s.dup
-          if body.encoding.name == "ASCII-8BIT"
+          if body.encoding == Encoding::BINARY
             "Binary (#{body.size} bytes)"
           else
             body
@@ -129,7 +129,7 @@ module Faraday
           ::JSON.generate(response_json)
         else
           body = env.body.to_s.dup
-          if body.encoding.name == "ASCII-8BIT"
+          if body.encoding == Encoding::BINARY
             "Binary (#{body.size} bytes)"
           else
             body


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576